### PR TITLE
Reduce the total number of break and continue statements in this loop to use at most one.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/share/ShareUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/share/ShareUtils.java
@@ -87,20 +87,27 @@ public class ShareUtils {
 
         ContentProviderUtils contentProviderUtils = new ContentProviderUtils(context);
         ArrayList<Uri> uris = new ArrayList<>();
+        
+        boolean shouldbreak = false;
         for (Marker.Id markerId : markerIds) {
             Marker marker = contentProviderUtils.getMarker(markerId);
             if (marker == null) {
                 Log.e(TAG, "MarkerId " + markerId.id() + " could not be resolved.");
-                continue;
+                shouldbreak = true;
             }
-            if (marker.getPhotoURI() == null) {
+            else if (marker.getPhotoURI() == null) {
                 Log.e(TAG, "MarkerId " + markerId.id() + " has no picture.");
-                continue;
+                shouldbreak = true;
+            }
+            else{
+                mime = context.getContentResolver().getType(marker.getPhotoURI());
+                uris.add(marker.getPhotoURI());
             }
 
-            mime = context.getContentResolver().getType(marker.getPhotoURI());
-
-            uris.add(marker.getPhotoURI());
+            if(shouldbreak){
+                shouldbreak = false;
+                continue;
+            }
         }
 
         if (uris.isEmpty()) {


### PR DESCRIPTION
Describe the pull request
Reduce the total number of break and continue statements in this loop to use at most one.
from src/main/java/de/dennisguse/opentracks/share/ShareUtils.java

Link to the issue
[Issue Link](https://github.com/numanSlm/OpenTracks-Winter-SOEN-6431_2024/issues/9)