### PR TITLE
Define and throw a dedicated exception instead of using a generic one.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/share/ShareUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/share/ShareUtils.java
@@ -34,7 +34,7 @@ public class ShareUtils {
      */
     public static Intent newShareFileIntent(Context context, Track.Id... trackIds) {
         if (trackIds.length == 0) {
-            throw new RuntimeException("Need to share at least one track.");
+            throw new ShareUtilsException("Need to share at least one track.");
         }
 
         ContentProviderUtils contentProviderUtils = new ContentProviderUtils(context);

--- a/src/main/java/de/dennisguse/opentracks/share/ShareUtilsException.java
+++ b/src/main/java/de/dennisguse/opentracks/share/ShareUtilsException.java
@@ -1,0 +1,5 @@
+package de.dennisguse.opentracks.share;
+
+public class ShareUtilsException extends RuntimeException{
+    public ShareUtilsException (String message) { super(message);}
+}


### PR DESCRIPTION
Define and throw a dedicated exception instead of using a generic one.