### PR TITLE
reorder modifiers to comply with java language specification

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/util/PermissionRequester.java
+++ b/src/main/java/de/dennisguse/opentracks/util/PermissionRequester.java
@@ -102,12 +102,12 @@ public class PermissionRequester {
         ALL_PERMISSIONS = Collections.unmodifiableList(recording);
     }
 
-    public final static PermissionRequester GPS = new PermissionRequester(GPS_PERMISSION);
-    public final static PermissionRequester BLUETOOTH = new PermissionRequester(BLUETOOTH_PERMISSIONS);
-    public final static PermissionRequester NOTIFICATION = new PermissionRequester(NOTIFICATION_PERMISSIONS);
+    public static final PermissionRequester GPS = new PermissionRequester(GPS_PERMISSION);
+    public static final PermissionRequester BLUETOOTH = new PermissionRequester(BLUETOOTH_PERMISSIONS);
+    public static final PermissionRequester NOTIFICATION = new PermissionRequester(NOTIFICATION_PERMISSIONS);
 
-    public final static PermissionRequester ALL = new PermissionRequester(ALL_PERMISSIONS);
-    public final static PermissionRequester RECORDING = new PermissionRequester(RECORDING_PERMISSIONS);
+    public static final PermissionRequester ALL = new PermissionRequester(ALL_PERMISSIONS);
+    public static final PermissionRequester RECORDING = new PermissionRequester(RECORDING_PERMISSIONS);
 
     public interface RejectedCallback {
         void rejected(PermissionRequester permissionRequester);


### PR DESCRIPTION
Fixed the Issue #16 by reordering the modifiers static and final