### PR TITLE
Changed the name of the exception from a generic to a dedicated one

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/share/ShareUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/share/ShareUtils.java
@@ -80,7 +80,7 @@ public class ShareUtils {
     @Nullable
     public static Intent newShareFileIntent(Context context, Marker.Id... markerIds) {
         if (markerIds.length == 0) {
-            throw new RuntimeException("Need to share at least one marker.");
+            throw new ShareUtilsException("Need to share at least one marker.");
         }
 
         String mime = null;


### PR DESCRIPTION
**Technical Debt :** 
Changed the Name of the Exception from a Generic to a Dedicated One.

**Details :** 
The software qualities impacted by this issue is Maintainibility because a generic exception doesnt help fix out edge cases when an error occurs. Changing name into dedicated exceptions helps to figure out the edge cases. Threw that exception into the code as well.